### PR TITLE
Support for org level secrets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 1.3.0
+
+- Add support for organization level secrets
+
 ## [1.2.1]
 
 - Fix lack of processing when no --repos flag is specified

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # github-repo-secrets-manager
 
-Manage github repo secrets using a common configuration file
+Manage github repo secrets using a common configuration file.  Supports repos, orgs and groups of secrets.
 
 ## Installation
 
@@ -9,12 +9,16 @@ git clone rewindio/github-repo-secrets-manager
 pip3 install -r requirements.txt
 ```
 
+## Prerequistes
+
+- A Github Personal Access Token (PAT) that has repo and admin:org scopes
+
 ## Usage
 
 ```bash
 usage: github-secrets-manager.py [-h] --secrets-file SECRETS_FILENAME
                                  --github-pat GITHUB_PAT [--verbose]
-                                 [--dryrun]
+                                 [--repos REPOS_FILTER] [--dryrun]
 
 Synchronize secrets with github repos
 
@@ -24,10 +28,8 @@ optional arguments:
                         Secrets file
   --github-pat GITHUB_PAT
                         Github access token
-  --repos REPOS_FILTER
-                        Comma separated list of repos to be updated
-
   --verbose             Turn on DEBUG logging
+  --repos REPOS_FILTER  Comma separated list of repos to be updated
   --dryrun              Do a dryrun - no changes will be performed
 ```
 
@@ -35,9 +37,10 @@ optional arguments:
 ./github-secrets-manager.py --secrets-file github_secrets.yaml --github-pat 123456789
 ```
 
-**Note**
-The --repos option acts only as a filter when processing the secrets file.
-The repos must be defined in the secrets file to be updated
+### Notes
+
+- The --repos option acts only as a filter when processing the secrets file.
+- The repos must be defined in the secrets file to be updated
 
 ## Configuration File
 
@@ -71,6 +74,12 @@ secrets:
       - myorg/repo-one
     groups:
       - koalas
+  -
+    name: SECRET4
+    value: 'an org level secret'
+
+    orgs:
+      - acme
 ```
 
 **Note**

--- a/github-secrets-manager.py
+++ b/github-secrets-manager.py
@@ -32,98 +32,132 @@ def encrypt(public_key: str, secret_value: str) -> str:
     encrypted = sealed_box.encrypt(secret_value.encode("utf-8"))
     return b64encode(encrypted).decode("utf-8")
 
+""" Test if the path is an org or a repo"""
+def is_repo(path):
+    if '/' in path:
+        return True
 
-def get_repo_public_key(repo_path, github_handle):
+    return False
+
+"""Get the public key used to encrypt secrets for the org or a repo"""
+def get_public_key(path, github_handle):
     global public_key_cache
+    gh_status = 0
     key = {'key_id': '', 'key': ''}
 
-    if repo_path in public_key_cache:
-        logging.debug("Public key cache hit for repo %s" % repo_path)
-        key = public_key_cache[repo_path]
+    if path in public_key_cache:
+        logging.debug("Public key cache hit for %s" % path)
+        key = public_key_cache[path]
     else:
-        logging.debug("Public key cache miss for repo %s" % repo_path)
-        owner, repo = repo_path.split('/')
-        gh_status, data = github_handle.repos[owner][repo].actions.secrets['public-key'].get()
+        logging.debug("Public key cache miss for %s" % path)
+
+        if is_repo(path):
+            owner, repo = path.split('/')
+
+            if owner and repo:
+                gh_status, data = github_handle.repos[owner][repo].actions.secrets['public-key'].get()
+            else:
+                logging.error("unable to determine owner and repo from %s" % path)
+        else:
+            # org key
+            gh_status, data = github_handle.orgs[path].actions.secrets['public-key'].get()
 
         if gh_status == 200:
-            logging.debug("Successfully read private key for repo %s" % repo_path)
-            public_key_cache[repo_path] = data
+            logging.debug("Successfully read private key for %s" % path)
+            public_key_cache[path] = data
             key = data
         else:
-            logging.error("Error reading private key for repo %s : %d" % (repo_path, gh_status))
+            logging.error("Error reading private key for %s : %d" % (path, gh_status))
 
     return key
 
-
-def secret_exists(repo_path, secret_name, github_handle):
+"""Check if a secret already exists on a repo or for the org"""
+def secret_exists(path, secret_name, github_handle):
     status = False
-    owner, repo = repo_path.split('/')
+    gh_status = 0
 
-    if owner and repo:
-        gh_status, data = github_handle.repos[owner][repo].actions.secrets[secret_name].get()
+    if is_repo(path):
+        owner, repo = path.split('/')
 
-        if gh_status == 200:
-            status = True
-    else:
-        logging.error("unable to determine owner and repo from %s" % repo_path)
-
-    return status
-
-
-def upsert_secret(repo_path, secret_name, secret_val, github_handle):
-    """Add or update a secret in a github repo."""
-    status = False
-    owner, repo = repo_path.split('/')
-
-    if owner and repo:
-        public_key = get_repo_public_key(repo_path, github_handle)
-
-        if public_key['key']:
-            encrypted_secret = encrypt(public_key['key'], secret_val)
-
-            if public_key['key_id']:
-                request_body = {'encrypted_value': encrypted_secret, 'key_id': public_key['key_id']}
-                request_headers = {'Content-Type': 'application/json'}
-
-                gh_status, data = github_handle.repos[owner][repo].actions.secrets[secret_name].put(body=request_body, headers=request_headers)
-
-                if gh_status == 204 or gh_status == 201:
-                    status = True
-                else:
-                    logger.error("Error upserting secret %s : %d" % (repo_path, gh_status))
-            else:
-                logging.error("No public key ID - unable to upsert secret")
+        if owner and repo:
+            gh_status, data = github_handle.repos[owner][repo].actions.secrets[secret_name].get()
         else:
-            logging.error("No public key - unable to upsert secret")
+            logging.error("unable to determine owner and repo from %s" % path)
     else:
-        logging.error("unable to determine owner and repo from %s" % repo_path)
+        # This is an org secret
+        gh_status, data = github_handle.orgs[path].actions.secrets[secret_name].get()
 
+    if gh_status == 200:
+        status = True
+    
     return status
 
-
-def remove_secret(repo_path, secret_name, github_handle):
-    """Remove a secret from a github repo."""
+"""Add or update a secret in a github repo or org"""
+def upsert_secret(path, secret_name, secret_val, github_handle):
     status = False
-    owner, repo = repo_path.split('/')
+    gh_status = 0
 
-    if owner and repo:
-        if secret_exists(repo_path, secret_name, github_handle):
-            gh_status, data = github_handle.repos[owner][repo].actions.secrets[secret_name].delete()
+    logger.info("Upserting path:%s sec:%s val:%s" % (path, secret_name, secret_val))
 
-            if gh_status == 204:
+    public_key = get_public_key(path, github_handle)
+
+    if public_key['key']:
+        if public_key['key_id']:
+            encrypted_secret = encrypt(public_key['key'], str(secret_val))
+
+            request_body = {'encrypted_value': encrypted_secret, 'key_id': public_key['key_id']}
+            request_headers = {'Content-Type': 'application/json'}
+
+            if is_repo(path):
+                owner, repo = path.split('/')
+
+                if owner and repo:
+                    gh_status, data = github_handle.repos[owner][repo].actions.secrets[secret_name].put(body=request_body, headers=request_headers)
+                else:
+                    logging.error("unable to determine owner and repo from %s" % path)
+            else:
+                # org secret
+                request_body['visibility'] = 'private'  # this secret will only be visible to private repos in the org
+                gh_status, data = github_handle.orgs[path].actions.secrets[secret_name].put(body=request_body, headers=request_headers)
+
+            if gh_status == 204 or gh_status == 201:
                 status = True
             else:
-                logger.error("Error removing secret %s : %d" % (repo_path, gh_status))
+                logger.error("Error upserting secret %s : %d" % (path, gh_status))
         else:
-            status = True  # Treat as if it was a removal if secret does not exist
+            logging.error("No public key ID - unable to upsert secret")
     else:
-        logging.error("unable to determine owner and repo from %s" % repo_path)
+        logging.error("No public key - unable to upsert secret")
+
+    return status
+
+"""Remove a secret from a github repo or org"""
+def remove_secret(path, secret_name, github_handle):
+    status = False
+
+    if secret_exists(path, secret_name, github_handle):
+        if is_repo(path):
+            owner, repo = path.split('/')
+
+            if owner and repo:
+                gh_status, data = github_handle.repos[owner][repo].actions.secrets[secret_name].delete()
+            else:
+                logging.error("unable to determine owner and repo from %s" % path)
+        else:
+            # org secret
+            gh_status, data = github_handle.orgs[path].actions.secrets[secret_name].delete()
+
+        if gh_status == 204:
+            status = True
+        else:
+            logger.error("Error removing secret %s : %d" % (path, gh_status))
+    else:
+        status = True  # Treat as if it was a removal if secret does not exist
 
     return status
 
 
 if __name__ == "__main__":
-
     secrets = {}
     public_key_cache = {}
     repos_filter = []
@@ -169,13 +203,12 @@ if __name__ == "__main__":
     # Initialize connection to Github API
     github_handle = GitHub(token=args.github_pat)
 
-    # Loop over every entry in the config
-    # For each entry, get the public key for the repo and encrpt the secret
-    # Write the secret
-
+    # Loop over each secret in the config file
+    # For each, determine if we are adding it to a repo or globally to an org
     for secret in secrets['secrets']:
         remove = False
         repos = []
+        orgs = []
 
         if secret and 'name' in secret:
             secret_name = secret['name'].strip()
@@ -195,40 +228,45 @@ if __name__ == "__main__":
                 else:
                     logging.info("No group defined for %s" % group)
 
+        if 'orgs' in secret:
+            orgs.extend(secret['orgs'])
+
         if 'repos' in secret:
             repos.extend(secret['repos'])
 
+        # Process any org values first
+        if orgs:
+            for org in orgs:
+                if remove:
+                    if dryrun:
+                        logging.info("DRYRUN: Removing %s from org %s" % (secret_name, org))
+                    else:
+                        if remove_secret(org, secret_name, github_handle):
+                            logging.info("Successfully removed secret %s from org %s" % (secret_name, org))
+                        else:
+                            logging.error("Unable to remove secret %s from org %s" % (secret_name, org))
+                else:
+                    if dryrun:
+                        logging.info("DRYRUN: Adding %s to org %s" % (secret_name, org))
+                    else:
+                        if upsert_secret(org, secret_name, secret_val, github_handle):
+                            logging.info("Successfully added/updated secret %s in org %s" % (secret_name, org))
+                        else:
+                            logging.error("Unable to add/update secret %s in org %s" % (secret_name, org))
+                
         if repos:
             for repo in repos:
                 repo = repo.strip()
 
-                if len(repos_filter) > 0:
-                    if repo in repos_filter:
-                        if remove:
-                            if dryrun:
-                                logging.info("DRYRUN: Removing %s from %s" % (secret_name, repo))
-                            else:
-                                if remove_secret(repo, secret_name, github_handle):
-                                    logging.info("Successfully removed secret %s from %s" % (secret_name, repo))
-                                else:
-                                    logging.error("Unable to remove secret %s from %s" % (secret_name, repo))
-                        else:
-                            if dryrun:
-                                logging.info("DRYRUN: Adding %s to %s" % (secret_name, repo))
-                            else:
-                                if upsert_secret(repo, secret_name, secret_val, github_handle):
-                                    logging.info("Successfully added/updated secret %s in repo %s" % (secret_name, repo))
-                                else:
-                                    logging.error("Unable to add/update secret %s in repo %s" % (secret_name, repo))
-                else:
+                if ( len(repos_filter) > 0 and repo in repos_filter) or len(repos_filter) == 0:
                     if remove:
                         if dryrun:
-                            logging.info("DRYRUN: Removing %s from %s" % (secret_name, repo))
+                            logging.info("DRYRUN: Removing %s from repo %s" % (secret_name, repo))
                         else:
                             if remove_secret(repo, secret_name, github_handle):
-                                logging.info("Successfully removed secret %s from %s" % (secret_name, repo))
+                                logging.info("Successfully removed secret %s from repo %s" % (secret_name, repo))
                             else:
-                                logging.error("Unable to remove secret %s from %s" % (secret_name, repo))
+                                logging.error("Unable to remove secret %s from repo %s" % (secret_name, repo))
                     else:
                         if dryrun:
                             logging.info("DRYRUN: Adding %s to %s" % (secret_name, repo))
@@ -237,7 +275,5 @@ if __name__ == "__main__":
                                 logging.info("Successfully added/updated secret %s in repo %s" % (secret_name, repo))
                             else:
                                 logging.error("Unable to add/update secret %s in repo %s" % (secret_name, repo))
-        else:
-            logging.error("No name for secret - unable to manage")
 
     logging.info("Complete")

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ SCRIPTS = ["github-repo-secrets-manager"]
 
 setup(
     name=NAME,
-    version="1.2.1",
+    version="1.3.0",
     description="Manage github repo secrets using a common configuration file",
     long_description=open("README.md").read(),
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Add in support for org level secrets.  This does require a Github PAT with the `admin:org` scope to use this functionality. 

The config file would look like:

```yaml
secrets:
  -
    name: TEST_ORG_SECRET
    value: 'foo'
    orgs:
      - acme
  -
    name: TEST_REPO_SECRET
    value: 'someval'
    repos:
      - acme/some_repo
  -
    name: TEST_BOTH_SECRET
    value: 'someval'
    repos:
      - rewindio/active_stream
    orgs:
      - acme
```