### PR TITLE
bump pyyaml to stay compatible with aws-param-store-sync

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 agithub~=2.2
-pyYAML~=5.3
+pyYAML~=6.0
 PyNaCl~=1.3.0


### PR DESCRIPTION
Trying to run this after python 3.10 was installed and it refused to build/install.
Bumping the version to align with the other tool allowed it to build and install locally.

```
ERROR: pip's dependency resolver does not currently take into account all the packages that are installed. This behaviour is the source of the following dependency conflicts.
aws-parameter-store-sync 0.1.0 requires PyYAML<7.0,>=6.0, but you have pyyaml 5.4.1 which is incompatible.
```

https://github.com/rewindio/aws-parameter-store-sync/blob/main/poetry.lock#L52-L58

Stuff like this makes me think we should have these tools in our private homebrew tap.