### PR TITLE
chore(): pin third-party actions to sha

### DIFF
--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -2,7 +2,7 @@ name: tag-and-release
 
 on:
   push:
-    branches: 
+    branches:
       - main
     paths: 'setup.py'
 
@@ -21,7 +21,7 @@ jobs:
         echo version_tag=v$version >> $GITHUB_OUTPUT
 
     - name: Tag commit
-      uses: tvdias/github-tagger@v0.0.1
+      uses: tvdias/github-tagger@ed7350546e3e503b5e942dffd65bc8751a95e49d
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         tag: "${{steps.get_version.outputs.version_tag}}"
@@ -46,7 +46,7 @@ jobs:
         echo "SHA256: ${checksum}" >> REL-BODY.md
 
     - name: Create Release
-      uses: ncipollo/release-action@v1
+      uses: ncipollo/release-action@a2e71bdd4e7dab70ca26a852f29600c98b33153e
       with:
         tag: ${{steps.get_version.outputs.version_tag}}
         artifacts: "github-secrets-manager*.tar.gz, sha256.sum"

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -21,7 +21,7 @@ jobs:
         echo version_tag=v$version >> $GITHUB_OUTPUT
 
     - name: Tag commit
-      uses: tvdias/github-tagger@ed7350546e3e503b5e942dffd65bc8751a95e49d
+      uses: tvdias/github-tagger@ed7350546e3e503b5e942dffd65bc8751a95e49d # v0.0.2
       with:
         repo-token: "${{ secrets.GITHUB_TOKEN }}"
         tag: "${{steps.get_version.outputs.version_tag}}"
@@ -46,7 +46,7 @@ jobs:
         echo "SHA256: ${checksum}" >> REL-BODY.md
 
     - name: Create Release
-      uses: ncipollo/release-action@a2e71bdd4e7dab70ca26a852f29600c98b33153e
+      uses: ncipollo/release-action@6c75be85e571768fa31b40abf38de58ba0397db5 # v1.13.0
       with:
         tag: ${{steps.get_version.outputs.version_tag}}
         artifacts: "github-secrets-manager*.tar.gz, sha256.sum"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
           pytest --junitxml=pytest.xml --cov=. test*.py > pytest-coverage.txt
 
       - name: Comment coverage
-        uses: MishaKav/pytest-coverage-comment@23f81a94faaa03449d5c4a729c0dd0b8d6abed96
+        uses: MishaKav/pytest-coverage-comment@23f81a94faaa03449d5c4a729c0dd0b8d6abed96 # v1.1.48
         with:
           pytest-coverage-path: ./pytest-coverage.txt
           junitxml-path: ./pytest.xml

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
           pytest --junitxml=pytest.xml --cov=. test*.py > pytest-coverage.txt
 
       - name: Comment coverage
-        uses: MishaKav/pytest-coverage-comment@main
+        uses: MishaKav/pytest-coverage-comment@23f81a94faaa03449d5c4a729c0dd0b8d6abed96
         with:
           pytest-coverage-path: ./pytest-coverage.txt
           junitxml-path: ./pytest.xml


### PR DESCRIPTION
```
- Update third party GHA to use SHA
- Update tvdias/github-tagger to v0.0.2
- Update ncipollo/release-action to v1.13.0
- Update MishaKav/pytest-coverage-comment to v1.1.48