### PR TITLE
chore(): pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,4 @@
 version: 2
-
 updates:
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
@@ -7,5 +6,11 @@ updates:
     schedule:
       interval: "weekly"
     labels:
-      - "appsec"
+      - appsec
     open-pull-requests-limit: 10
+    groups:
+      minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - patch
+          - minor

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # main
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Get version
         id: get_version

--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -11,44 +11,44 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@main
+      - uses: actions/checkout@0c366fd6a839edf440554fa01a7085ccba70ac98 # main
 
-    - name: Get version
-      id: get_version
-      run: |
-        version=$(grep "version=" setup.py | cut -f2 -d"=" |tr -d "\""|tr -d ",")
-        echo version=$version >> $GITHUB_OUTPUT
-        echo version_tag=v$version >> $GITHUB_OUTPUT
+      - name: Get version
+        id: get_version
+        run: |
+          version=$(grep "version=" setup.py | cut -f2 -d"=" |tr -d "\""|tr -d ",")
+          echo version=$version >> $GITHUB_OUTPUT
+          echo version_tag=v$version >> $GITHUB_OUTPUT
 
-    - name: Tag commit
-      uses: tvdias/github-tagger@ed7350546e3e503b5e942dffd65bc8751a95e49d # v0.0.2
-      with:
-        repo-token: "${{ secrets.GITHUB_TOKEN }}"
-        tag: "${{steps.get_version.outputs.version_tag}}"
+      - name: Tag commit
+        uses: tvdias/github-tagger@ed7350546e3e503b5e942dffd65bc8751a95e49d # v0.0.2
+        with:
+          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          tag: "${{steps.get_version.outputs.version_tag}}"
 
-    - name: Extract from changelog
-      id: extract_changes
-      run: |
-        # Must use a temporary file or it loses the formatting
-        VERSION=${{steps.get_version.outputs.version}}; awk "/## \[$VERSION\]/{flag=1;next}/## \[/{flag=0}flag" CHANGELOG.md > REL-BODY.md
+      - name: Extract from changelog
+        id: extract_changes
+        run: |
+          # Must use a temporary file or it loses the formatting
+          VERSION=${{steps.get_version.outputs.version}}; awk "/## \[$VERSION\]/{flag=1;next}/## \[/{flag=0}flag" CHANGELOG.md > REL-BODY.md
 
-    - name: Create Relase TAR
-      id: create_tar
-      run: |
-        mv github-secrets-manager.py github-secrets-manager
-        tar cvzf ./github-secrets-manager-${{steps.get_version.outputs.version}}.tar.gz github-secrets-manager* requirements.txt setup.py README.md
+      - name: Create Relase TAR
+        id: create_tar
+        run: |
+          mv github-secrets-manager.py github-secrets-manager
+          tar cvzf ./github-secrets-manager-${{steps.get_version.outputs.version}}.tar.gz github-secrets-manager* requirements.txt setup.py README.md
 
-    - name: Generate Checksum
-      id: generate_checksum
-      run: |
-        checksum=$(sha256sum ./github-secrets-manager-${{steps.get_version.outputs.version}}.tar.gz | awk '{print $1}')
-        echo "${checksum}" > sha256.sum
-        echo "SHA256: ${checksum}" >> REL-BODY.md
+      - name: Generate Checksum
+        id: generate_checksum
+        run: |
+          checksum=$(sha256sum ./github-secrets-manager-${{steps.get_version.outputs.version}}.tar.gz | awk '{print $1}')
+          echo "${checksum}" > sha256.sum
+          echo "SHA256: ${checksum}" >> REL-BODY.md
 
-    - name: Create Release
-      uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
-      with:
-        tag: ${{steps.get_version.outputs.version_tag}}
-        artifacts: "github-secrets-manager*.tar.gz, sha256.sum"
-        bodyFile: "REL-BODY.md"
-        token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Create Release
+        uses: ncipollo/release-action@339a81892b84b4eeb0f6e744e4574d79d0d9b8dd # v1.21.0
+        with:
+          tag: ${{steps.get_version.outputs.version_tag}}
+          artifacts: "github-secrets-manager*.tar.gz, sha256.sum"
+          bodyFile: "REL-BODY.md"
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
         run: pip install -r requirements-test.txt
 
       - name: Format
-        uses: psf/black@c6755bb741b6481d6b3d3bb563c83fa060db96c9 # 26.3.1
+        run: black . --check
 
       - name: Test
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,10 +14,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: Set up python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6
         with:
           python-version: ${{ env.PYTHON_VERSION }}
 
@@ -25,10 +25,10 @@ jobs:
         run: pip install -r requirements-test.txt
 
       - name: Format
-        uses: psf/black@stable
+        uses: psf/black@35ea67920b7f6ac8e09be1c47278752b1e827f76 # stable
 
       - name: Test
-        run:  |
+        run: |
           pytest --junitxml=pytest.xml --cov=. test*.py > pytest-coverage.txt
 
       - name: Comment coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
         run: pip install -r requirements-test.txt
 
       - name: Format
-        uses: psf/black@35ea67920b7f6ac8e09be1c47278752b1e827f76 # stable
+        uses: psf/black@c6755bb741b6481d6b3d3bb563c83fa060db96c9 # 26.3.1
 
       - name: Test
         run: |


### PR DESCRIPTION
# Pin GitHub Actions to commit SHAs

## Description of change

Pins all third-party GitHub Actions to specific commit SHAs to protect
against tag hijacking / supply chain attacks. Actions from the `rewindio`
org are excluded and remain at their original version refs.

Uses [ratchet](https://github.com/sethvargo/ratchet) for SHA resolution.

## Testing Performed
