### PR TITLE
chore: update CODEOWNERS team refs to rewind-community

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -2,6 +2,6 @@
 
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence, members of
-# @rewindio/codeowners will be requested for review when someone
+# @rewind-community/codeowners will be requested for review when someone
 # opens a pull request.
-*       @rewindio/devops
+*       @rewind-community/devops


### PR DESCRIPTION
# **Jira:** [DEVOPS-4349](https://rewind.atlassian.net/browse/DEVOPS-4349)

## Description of Change

This repo was moved from `rewindio` to `rewind-community`. CODEOWNERS still referenced `@rewindio/devops`; cross-org team refs are silently dropped by GitHub, so codeowner review was effectively disabled. Updating to `@rewind-community/devops` restores it.

## Related PRs

- rewindio/terraform-rewindio-github#365

## Testing Performed

Team `rewind-community/devops` exists. Visual diff review.