### PR TITLE
fix(ci): tag and release via rewind-community-tagger app token

### DIFF
--- a/.github/workflows/tag-and-release.yml
+++ b/.github/workflows/tag-and-release.yml
@@ -10,6 +10,9 @@ jobs:
   release:
     runs-on: ubuntu-latest
 
+    permissions:
+      contents: read
+
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -20,10 +23,17 @@ jobs:
           echo version=$version >> $GITHUB_OUTPUT
           echo version_tag=v$version >> $GITHUB_OUTPUT
 
+      - name: Create tagger app token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3
+        with:
+          app-id: ${{ secrets.TAGGER_APP_ID }}
+          private-key: ${{ secrets.TAGGER_PRIVATE_KEY }}
+
       - name: Tag commit
         uses: tvdias/github-tagger@ed7350546e3e503b5e942dffd65bc8751a95e49d # v0.0.2
         with:
-          repo-token: "${{ secrets.GITHUB_TOKEN }}"
+          repo-token: "${{ steps.app-token.outputs.token }}"
           tag: "${{steps.get_version.outputs.version_tag}}"
 
       - name: Extract from changelog
@@ -51,4 +61,4 @@ jobs:
           tag: ${{steps.get_version.outputs.version_tag}}
           artifacts: "github-secrets-manager*.tar.gz, sha256.sum"
           bodyFile: "REL-BODY.md"
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Why

`tag-and-release` in this repo would fail on its first real release. This is **latent, not a live failure** — the workflow has never run here and the latest tag is `v1.3.0`, so nothing is pending. It fires on a push to `main` that touches `setup.py` (where the version lives).

Two sibling repos hit exactly this today: [omniauth-azure-devops run 31500836484](https://github.com/rewind-community/omniauth-azure-devops/actions/runs/31500836484) and [omniauth-miro run 31500848095](https://github.com/rewind-community/omniauth-miro/actions/runs/31500848095), both dying at `Tag commit` with `HttpError: Resource not accessible by integration`.

There are **two** separate barriers in front of `GITHUB_TOKEN`, and fixing only the first is not enough.

**1. The token is read-only.** The workflow declared no `permissions:` block, so it inherits the repo default (`default_workflow_permissions: read`). The tagger action's only operation is `git.createRef` → `POST /git/refs`, which requires `contents: write`.

**2. `contents: write` alone would still fail.** The org-level ruleset `rewind-tag` is `active` over `~ALL` tags and carries a `creation` rule, restricting tag creation to two bypass actors: `OrganizationAdmin` and the `rewind-community-tagger` App. `GITHUB_TOKEN` is neither, so it clears the permission check and is then rejected by the ruleset with `Reference update failed`.

This isn't speculation — `eight_ball` already ran the experiment:

| Run | Change | Result |
|---|---|---|
| [29513619634](https://github.com/rewind-community/eight_ball/actions/runs/29513619634) | grant `contents: write` | ❌ `Reference update failed` |
| [29515788879](https://github.com/rewind-community/eight_ball/actions/runs/29515788879) | use tagger app token | ✅ success |

## What

Mint a `rewind-community-tagger` installation token and use it for both `Tag commit` and `Create Release`. `ncipollo/release-action` also needs `contents: write` and creates the tag when it's absent, so it hits the same ruleset — both steps have to move to the app token. `GITHUB_TOKEN` is now pinned explicitly to `contents: read`.

Same fix already merged in [omniauth-azure-devops#43](https://github.com/rewind-community/omniauth-azure-devops/pull/43) and [omniauth-miro#38](https://github.com/rewind-community/omniauth-miro/pull/38) — miro has since released `v1.0.8` through the app token, so this path is proven end-to-end, not just green in CI. Companion PRs: [aws-connect#31](https://github.com/rewind-community/aws-connect/pull/31), [dagwood#28](https://github.com/rewind-community/dagwood/pull/28).

Notes:

- The app is installed org-wide (`repository_selection: all`) and holds `contents: write`, so no per-repo install is needed.
- `TAGGER_APP_ID` and `TAGGER_PRIVATE_KEY` are existing org secrets, already confirmed visible to this repo.
- `create-github-app-token` is pinned to the `v3` tag SHA, which resolves to release **3.2.0** — the latest stable (2026-05-12).
- The tarball and checksum steps are untouched; only the two token-consuming steps and the `permissions` block change.

## Test plan

- [x] YAML parses (Ruby psych); `permissions` is `{contents: read}`
- [x] `Create tagger app token` step ordered before `Tag commit`
- [x] Both `repo-token` and `token` resolve to `steps.app-token.outputs.token`; zero `secrets.GITHUB_TOKEN` left in this workflow
- [x] Tagger app installed on this repo with `contents: write`, and present in the `rewind-tag` bypass actors
- [x] Nothing pending: `tag-and-release` has never run here, latest tag is `v1.3.0`
- [ ] End-to-end confirmation on the next `setup.py` version bump

🤖 Generated with [Claude Code](https://claude.com/claude-code)